### PR TITLE
Refactor operand options

### DIFF
--- a/src/js/expression-group.js
+++ b/src/js/expression-group.js
@@ -74,6 +74,9 @@ angular.module('ngEquation')
                             event.relatedTarget.classList.add('can-drop');
 
                             // change operand's snap target to be this group
+                            // otherwise when the operand is dropped the drop event will be
+                            // triggered with the original location of the operand
+                            // (the snap happens before the drop is triggered)
 
                             var dropRect = interact.getElementRect(event.target),
                                 dropCenter = {

--- a/src/js/expression-group.js
+++ b/src/js/expression-group.js
@@ -114,9 +114,37 @@ angular.module('ngEquation')
                                 groupCtrl.addOperand(operandCtrl.options);
                             });
 
-                            scope.$apply(function() {
-                                operandCtrl.removeFromGroup();
-                            });
+                            if (operandCtrl.group) {
+
+                                // remove from old group
+
+                                scope.$apply(function() {
+                                    operandCtrl.removeFromGroup();
+                                });
+
+                            } else {
+
+                                // restore operand's snap target to its original position
+
+                                event.draggable.draggable({
+                                    snap: {
+                                        targets: [{
+                                            x: parseFloat(event.relatedTarget.getAttribute('data-start-x')),
+                                            y: parseFloat(event.relatedTarget.getAttribute('data-start-y'))
+                                        }]
+                                    }
+                                });
+
+                                // move operand to its original position
+
+                                event.relatedTarget.style.webkitTransform =
+                                    event.relatedTarget.style.transform =
+                                        'none';
+
+                                event.relatedTarget.setAttribute('data-x', 0);
+                                event.relatedTarget.setAttribute('data-y', 0);
+
+                            }
                         },
                         ondropdeactivate: function(event) {
                             event.target.classList.remove('drop-active');

--- a/src/js/expression-group.js
+++ b/src/js/expression-group.js
@@ -135,7 +135,7 @@ angular.module('ngEquation')
                             });
 
                             scope.$apply(function() {
-                                operandCtrl.options.removeOperand(operandCtrl.options);
+                                operandCtrl.removeFromGroup();
                             });
                         },
                         ondropdeactivate: function(event) {

--- a/src/js/expression-group.js
+++ b/src/js/expression-group.js
@@ -4,35 +4,8 @@ angular.module('ngEquation')
     .controller('ExpressionGroupCtrl', function() {
         var ctrl = this;
 
-        // extend this group's operands by supplying them with a method
-        // that removes them from the group when called
-        /* eslint-disable angular/controller-as-vm */
-        function OperandOptions(config) {
-            this.group = ctrl;
-            this.class = config.class;
-            this.label = config.label;
-            if (angular.isDefined(config.operator)) {
-                this.operator = config.operator;
-            }
-            if (angular.isDefined(config.operands)) {
-                this.operands = config.operands;
-            }
-        }
-
-        OperandOptions.prototype.removeOperand = function() {
-            var operandIndex = ctrl.getIndexOfOperand(this);
-            if (operandIndex !== -1) {
-                ctrl.operands.splice(operandIndex, 1);
-            }
-        };
-        /* eslint-enable angular/controller-as-vm */
-
-        ctrl.operands = ctrl.operands.map(function(operand) {
-            return new OperandOptions(operand);
-        });
-
         ctrl.addOperand = function(operand) {
-            ctrl.operands.push(new OperandOptions(operand));
+            ctrl.operands.push(operand);
         };
 
         ctrl.addSubgroup = function() {
@@ -54,6 +27,13 @@ angular.module('ngEquation')
 
         ctrl.removeSubgroup = function(subgroupId) {
             ctrl.operands.splice(subgroupId, 1);
+        };
+
+        ctrl.removeOperand = function(operand) {
+            var operandIndex = ctrl.getIndexOfOperand(operand);
+            if (operandIndex !== -1) {
+                ctrl.operands.splice(operandIndex, 1);
+            }
         };
     })
     .directive('expressionGroup', function($templateCache) {

--- a/src/js/expression-group.js
+++ b/src/js/expression-group.js
@@ -115,35 +115,33 @@ angular.module('ngEquation')
                             });
 
                             if (operandCtrl.group) {
-
                                 // remove from old group
 
                                 scope.$apply(function() {
                                     operandCtrl.removeFromGroup();
                                 });
-
                             } else {
-
                                 // restore operand's snap target to its original position
+
+                                var operandElement = event.relatedTarget;
 
                                 event.draggable.draggable({
                                     snap: {
                                         targets: [{
-                                            x: parseFloat(event.relatedTarget.getAttribute('data-start-x')),
-                                            y: parseFloat(event.relatedTarget.getAttribute('data-start-y'))
+                                            x: parseFloat(operandElement.getAttribute('data-start-x')),
+                                            y: parseFloat(operandElement.getAttribute('data-start-y'))
                                         }]
                                     }
                                 });
 
                                 // move operand to its original position
 
-                                event.relatedTarget.style.webkitTransform =
-                                    event.relatedTarget.style.transform =
+                                operandElement.style.webkitTransform =
+                                    operandElement.style.transform =
                                         'none';
 
-                                event.relatedTarget.setAttribute('data-x', 0);
-                                event.relatedTarget.setAttribute('data-y', 0);
-
+                                operandElement.setAttribute('data-x', 0);
+                                operandElement.setAttribute('data-y', 0);
                             }
                         },
                         ondropdeactivate: function(event) {

--- a/src/js/expression-operand-toolbox.js
+++ b/src/js/expression-operand-toolbox.js
@@ -4,19 +4,6 @@ angular.module('ngEquation')
     .controller('ExpressionOperandToolboxCtrl', function($timeout) {
         var ctrl = this;
 
-        // extend the operands in the toolbox by supplying them with a method
-        // that removes them from the toolbox, followed by a toolbox refresh
-        /* eslint-disable angular/controller-as-vm */
-        function OperandOptions(config) {
-            this.class = config.class;
-            this.label = config.label;
-        }
-
-        OperandOptions.prototype.removeOperand = function() {
-            ctrl.refresh(ctrl.getIndexOfOperand(this));
-        };
-        /* eslint-enable angular/controller-as-vm */
-
         ctrl.getIndexOfOperand = function(operand) {
             for (var i = 0; i < ctrl.operands.length; ++i) {
                 if (ctrl.operands[i].class === operand.class &&
@@ -31,19 +18,21 @@ angular.module('ngEquation')
 
         ctrl.refresh = function(operandIndex) {
             if (angular.isDefined(operandIndex) && operandIndex !== -1) {
-                var freshOperand = new OperandOptions(originalOperandsList[operandIndex]);
+                var freshOperand = angular.copy(originalOperandsList[operandIndex]);
                 ctrl.operands.splice(operandIndex, 1, freshOperand);
             } else {
                 ctrl.operands = [];
                 $timeout(function() {
-                    ctrl.operands = originalOperandsList.map(function(operand) {
-                        return new OperandOptions(operand);
-                    });
+                    ctrl.operands = angular.copy(originalOperandsList);
                 });
             }
         };
 
         ctrl.refresh();
+
+        ctrl.removeOperand = function(operand) {
+            ctrl.refresh(ctrl.getIndexOfOperand(operand));
+        };
     })
     .directive('expressionOperandToolbox', function($templateCache) {
         return {

--- a/src/js/expression-operand-toolbox.js
+++ b/src/js/expression-operand-toolbox.js
@@ -1,39 +1,7 @@
 'use strict';
 
 angular.module('ngEquation')
-    .controller('ExpressionOperandToolboxCtrl', function($timeout) {
-        var ctrl = this;
-
-        ctrl.getIndexOfOperand = function(operand) {
-            for (var i = 0; i < ctrl.operands.length; ++i) {
-                if (ctrl.operands[i].class === operand.class &&
-                    ctrl.operands[i].label === operand.label) {
-                    return i;
-                }
-            }
-            return -1;
-        };
-
-        var originalOperandsList = angular.copy(ctrl.operands);
-
-        ctrl.refresh = function(operandIndex) {
-            if (angular.isDefined(operandIndex) && operandIndex !== -1) {
-                var freshOperand = angular.copy(originalOperandsList[operandIndex]);
-                ctrl.operands.splice(operandIndex, 1, freshOperand);
-            } else {
-                ctrl.operands = [];
-                $timeout(function() {
-                    ctrl.operands = angular.copy(originalOperandsList);
-                });
-            }
-        };
-
-        ctrl.refresh();
-
-        ctrl.removeOperand = function(operand) {
-            ctrl.refresh(ctrl.getIndexOfOperand(operand));
-        };
-    })
+    .controller('ExpressionOperandToolboxCtrl', function() {})
     .directive('expressionOperandToolbox', function($templateCache) {
         return {
             restrict: 'EA',

--- a/src/js/expression-operand.js
+++ b/src/js/expression-operand.js
@@ -143,35 +143,33 @@ angular.module('ngEquation')
                             });
 
                             if (newOperandCtrl.group) {
-
                                 // remove from old group
 
                                 scope.$apply(function() {
                                     newOperandCtrl.removeFromGroup();
                                 });
-
                             } else {
-
                                 // restore new operand's snap target to its original position
+
+                                var newOperandElement = event.relatedTarget;
 
                                 event.draggable.draggable({
                                     snap: {
                                         targets: [{
-                                            x: parseFloat(event.relatedTarget.getAttribute('data-start-x')),
-                                            y: parseFloat(event.relatedTarget.getAttribute('data-start-y'))
+                                            x: parseFloat(newOperandElement.getAttribute('data-start-x')),
+                                            y: parseFloat(newOperandElement.getAttribute('data-start-y'))
                                         }]
                                     }
                                 });
 
                                 // move new operand to its original position
 
-                                event.relatedTarget.style.webkitTransform =
-                                    event.relatedTarget.style.transform =
+                                newOperandElement.style.webkitTransform =
+                                    newOperandElement.style.transform =
                                         'none';
 
-                                event.relatedTarget.setAttribute('data-x', 0);
-                                event.relatedTarget.setAttribute('data-y', 0);
-
+                                newOperandElement.setAttribute('data-x', 0);
+                                newOperandElement.setAttribute('data-y', 0);
                             }
                         },
                         ondropdeactivate: function(event) {

--- a/src/js/expression-operand.js
+++ b/src/js/expression-operand.js
@@ -95,6 +95,9 @@ angular.module('ngEquation')
                             event.relatedTarget.classList.add('can-drop');
 
                             // change new operand's snap target to be the existing operand
+                            // otherwise when the new operand is dropped the drop event will be
+                            // triggered with the original location of the new operand
+                            // (the snap happens before the drop is triggered)
 
                             var dropRect = interact.getElementRect(event.target),
                                 dropCenter = {

--- a/src/js/expression-operand.js
+++ b/src/js/expression-operand.js
@@ -4,14 +4,18 @@ angular.module('ngEquation')
     .controller('ExpressionOperandCtrl', function() {
         var ctrl = this;
 
-        // eslint-disable-next-line no-console, angular/log
-        console.log(ctrl.options.label);
+        ctrl.removeFromGroup = function() {
+            if (ctrl.group) {
+                ctrl.group.removeOperand(ctrl.options);
+            }
+        };
     })
     .directive('expressionOperand', function($templateCache) {
         return {
             restrict: 'EA',
             scope: {},
             bindToController: {
+                group: '=?',
                 options: '=operandOptions'
             },
             controller: 'ExpressionOperandCtrl',
@@ -71,10 +75,10 @@ angular.module('ngEquation')
                             var existingOperandScope = angular.element(dropElement).scope();
                             if (existingOperandScope) {
                                 var existingOperandCtrl = existingOperandScope.operand;
-                                if (dropped && existingOperandCtrl.options.group) {
+                                if (dropped && existingOperandCtrl.group) {
                                     var newOperandCtrl = angular.element(draggableElement).scope().operand;
 
-                                    return dropped && (existingOperandCtrl.options.group.getIndexOfOperand(newOperandCtrl.options) === -1);
+                                    return dropped && (existingOperandCtrl.group.getIndexOfOperand(newOperandCtrl.options) === -1);
                                 }
                             }
                             return false;
@@ -126,15 +130,15 @@ angular.module('ngEquation')
                                 existingOperandCtrl = angular.element(event.target).scope().operand;
 
                             scope.$apply(function() {
-                                existingOperandCtrl.options.group.addOperand({
+                                existingOperandCtrl.group.addOperand({
                                     operator: 'AND',
                                     operands: [existingOperandCtrl.options, newOperandCtrl.options]
                                 });
                             });
 
                             scope.$apply(function() {
-                                newOperandCtrl.options.removeOperand(newOperandCtrl.options);
-                                existingOperandCtrl.options.removeOperand(existingOperandCtrl.options);
+                                newOperandCtrl.removeFromGroup();
+                                existingOperandCtrl.removeFromGroup();
                             });
                         },
                         ondropdeactivate: function(event) {

--- a/src/js/expression-operand.js
+++ b/src/js/expression-operand.js
@@ -75,10 +75,12 @@ angular.module('ngEquation')
                             var existingOperandScope = angular.element(dropElement).scope();
                             if (existingOperandScope) {
                                 var existingOperandCtrl = existingOperandScope.operand;
-                                if (dropped && existingOperandCtrl.group) {
+                                if (dropped && existingOperandCtrl) {
                                     var newOperandCtrl = angular.element(draggableElement).scope().operand;
 
-                                    return dropped && (existingOperandCtrl.group.getIndexOfOperand(newOperandCtrl.options) === -1);
+                                    return dropped &&
+                                        (existingOperandCtrl.options.class !== newOperandCtrl.options.class ||
+                                         existingOperandCtrl.options.label !== newOperandCtrl.options.label);
                                 }
                             }
                             return false;

--- a/src/js/expression-operand.js
+++ b/src/js/expression-operand.js
@@ -137,9 +137,40 @@ angular.module('ngEquation')
                             });
 
                             scope.$apply(function() {
-                                newOperandCtrl.removeFromGroup();
                                 existingOperandCtrl.removeFromGroup();
                             });
+
+                            if (newOperandCtrl.group) {
+
+                                // remove from old group
+
+                                scope.$apply(function() {
+                                    newOperandCtrl.removeFromGroup();
+                                });
+
+                            } else {
+
+                                // restore new operand's snap target to its original position
+
+                                event.draggable.draggable({
+                                    snap: {
+                                        targets: [{
+                                            x: parseFloat(event.relatedTarget.getAttribute('data-start-x')),
+                                            y: parseFloat(event.relatedTarget.getAttribute('data-start-y'))
+                                        }]
+                                    }
+                                });
+
+                                // move new operand to its original position
+
+                                event.relatedTarget.style.webkitTransform =
+                                    event.relatedTarget.style.transform =
+                                        'none';
+
+                                event.relatedTarget.setAttribute('data-x', 0);
+                                event.relatedTarget.setAttribute('data-y', 0);
+
+                            }
                         },
                         ondropdeactivate: function(event) {
                             event.target.classList.remove('drop-active');

--- a/src/templates/expression-group.html
+++ b/src/templates/expression-group.html
@@ -19,6 +19,7 @@
         <!-- not subgroup -->
         <span ng-if="!operand.operands">
             <expression-operand
+                group="group"
                 operand-options="operand">
             </expression-operand>
         </span>

--- a/src/templates/expression-operand-toolbox.html
+++ b/src/templates/expression-operand-toolbox.html
@@ -3,7 +3,6 @@
     <span ng-repeat="operand in toolbox.operands">
 
         <expression-operand
-            group="toolbox"
             operand-options="operand">
         </expression-operand>
 

--- a/src/templates/expression-operand-toolbox.html
+++ b/src/templates/expression-operand-toolbox.html
@@ -3,6 +3,7 @@
     <span ng-repeat="operand in toolbox.operands">
 
         <expression-operand
+            group="toolbox"
             operand-options="operand">
         </expression-operand>
 

--- a/src/templates/expression-operand.html
+++ b/src/templates/expression-operand.html
@@ -4,8 +4,8 @@
         {{operand.options.label}}
 
         <button class="eq-remove-operand"
-            ng-if="operand.options.group"
-            ng-click="operand.options.removeOperand(operand.options)">
+            ng-if="operand.group"
+            ng-click="operand.removeFromGroup()">
             &times;
         </button>
     </span>


### PR DESCRIPTION
- deleted `OperandOptions` - it was really weird having the operand api defined by the group it's in...
  - instead, add `group` attribute to operands to pass their parent to them
  - and add a `removeFromGroup` method to operand to remove it from its parent
- deleted the code that removed operands from the toolbox and then refreshed the toolbox with a fresh version of that operand
  - now that operand is just moved back to its original position in the toolbox `{x: 0, y: 0}`
