### PR TITLE
Edit operand metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ grunt test
 ```
 
 ##### Demo
-Open demo/index.html in browser
+
+ * Run `http-server` from the root of the project (which can be installed via npm)
+ * Open [http://localhost:8080/demo/](demo URL) in browser
 
 ### Release
 

--- a/demo/app.js
+++ b/demo/app.js
@@ -1,43 +1,10 @@
+'use strict';
+
 angular.module('exampleApp', ['ngEquation'])
-    .controller('ExampleCtrl', function() {
+    .controller('ExampleCtrl', function(fruitOperand) {
         var ctrl = this;
 
-        ctrl.availableOperands = [
-            {label: 'A', class: 'a'},
-            {label: 'B', class: 'b'},
-            {label: 'C', class: 'c'},
-            {label: 'D', class: 'd'},
-            {label: 'E', class: 'e'},
-            {label: 'F', class: 'f'}
-        ];
-
         ctrl.config = {
-            availableOperands: ctrl.availableOperands
-        };
-
-        ctrl.equationOne = {
-            operator: 'OR',
-            operands: [
-                {label: 'A', class: 'a'},
-                {label: 'B', class: 'b'},
-                {label: 'C', class: 'c'},
-                {
-                    operator: 'AND',
-                    operands: [
-                        {label: 'D', class: 'd'},
-                        {label: 'E', class: 'e'},
-                        {label: 'F', class: 'f'}
-                    ]
-                }
-            ]
-        };
-
-        ctrl.equationTwo = {
-            operator: 'AND NOT',
-            operands: [
-                {label: 'X', class: 'a'},
-                {label: 'Y', class: 'b'},
-                {label: 'Z', class: 'c'}
-            ]
+            availableOperands: [fruitOperand.config()]
         };
     });

--- a/demo/fruit.js
+++ b/demo/fruit.js
@@ -1,0 +1,47 @@
+'use strict';
+
+angular.module('exampleApp')
+    .constant('fruits', ['apple', 'banana', 'lime', 'orange', 'plum'])
+    .factory('capitalize', function() {
+        return function(value) {
+            return value.charAt(0).toUpperCase() + value.slice(1);
+        };
+    })
+    .factory('fruitOperand', function($uibModal, capitalize, fruits) {
+        var launchEditModal = function() {
+            var modalInstance = $uibModal.open({
+                size: 'sm',
+                templateUrl: 'templates/fruit-select-modal.html',
+                controller: function($uibModalInstance, $scope) {
+                    $scope.fruits = fruits.map(function(fruit) {
+                        return {label: capitalize(fruit), value: fruit};
+                    });
+                    $scope.fruit = {};
+                    $scope.submit = function() {
+                        var value = $scope.fruit.selected && $scope.fruit.selected.value;
+                        $uibModalInstance.close(value);
+                    };
+                    $scope.cancel = function() {
+                        $uibModalInstance.dismiss();
+                    };
+                }
+            });
+
+            return modalInstance.result;
+        };
+
+        return {
+            config: function() {
+                return {
+                    class: 'fruit',
+                    typeLabel: 'Fruit',
+                    editMetadata: function() {
+                        return launchEditModal();
+                    },
+                    getLabel: function(operand) {
+                        return operand.value ? capitalize(operand.value) : 'N/A';
+                    }
+                };
+            }
+        };
+    });

--- a/demo/index.html
+++ b/demo/index.html
@@ -15,46 +15,23 @@
     <script src="dist/ng-equation-templates.js"></script>
 
     <script src="app.js"></script>
+    <script src="fruit.js"></script>
 
 </head>
 <body ng-controller="ExampleCtrl as example">
-<a href="https://github.com/miller-time/ng-equation"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
+    <a href="https://github.com/miller-time/ng-equation">
+        <img style="position: absolute; top: 0; right: 0; border: 0;"
+            src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67"
+            alt="Fork me on GitHub"
+            data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png">
+    </a>
+
     <div class="container">
         <h1>ng-equation demo</h1>
 
-        <p>
-            <equation
-                equation-options="example.config">
-            </equation>
-        </p>
-
-        <label>
-            Other Examples
-            <input type="checkbox" ng-model="example.showOtherExamples">
-        </label>
-
-        <div ng-show="example.showOtherExamples">
-            <p>
-                <label>Toolbox</label>
-                <expression-operand-toolbox
-                    operands="example.availableOperands">
-                </expression-operand-toolbox>
-            </p>
-
-            <p>
-                <expression-group
-                    operator="{{example.equationOne.operator}}"
-                    operands="example.equationOne.operands">
-                </expression-group>
-            </p>
-
-            <p>
-                <expression-group
-                    operator="{{example.equationTwo.operator}}"
-                    operands="example.equationTwo.operands">
-                </expression-group>
-            </p>
-        </div>
+        <equation
+            equation-options="example.config">
+        </equation>
     </div>
 </body>
 </html>

--- a/demo/style.css
+++ b/demo/style.css
@@ -21,7 +21,7 @@ label {
     box-shadow: 0px 0px 3px 3px darkgray;
 }
 
-.eq-operand.a, .eq-operand-menu-item.a {
+.eq-operand.fruit, .eq-operand-menu-item.fruit {
     background-color: lightblue;
 }
 

--- a/demo/templates/fruit-select-modal.html
+++ b/demo/templates/fruit-select-modal.html
@@ -1,0 +1,14 @@
+<div class="modal-body">
+    <div class="form-group">
+        <label>Fruit</label>
+        <select
+            class="form-control"
+            ng-options="fruit.label for fruit in fruits track by fruit.value"
+            ng-model="fruit.selected">
+        </select>
+    </div>
+</div>
+<div class="modal-footer">
+    <button ng-click="submit()">Submit</button>
+    <button ng-click="cancel()">Cancel</button>
+</div>

--- a/src/js/expression-group.js
+++ b/src/js/expression-group.js
@@ -5,7 +5,7 @@ angular.module('ngEquation')
         var ctrl = this;
 
         ctrl.addOperand = function(operand) {
-            ctrl.operands.push(operand);
+            ctrl.operands.push(angular.copy(operand));
         };
 
         ctrl.addSubgroup = function() {

--- a/src/js/expression-group.js
+++ b/src/js/expression-group.js
@@ -17,8 +17,7 @@ angular.module('ngEquation')
 
         ctrl.getIndexOfOperand = function(operand) {
             for (var i = 0; i < ctrl.operands.length; ++i) {
-                if (ctrl.operands[i].class === operand.class &&
-                    ctrl.operands[i].label === operand.label) {
+                if (ctrl.operands[i].value === operand.value) {
                     return i;
                 }
             }

--- a/src/js/expression-operand.js
+++ b/src/js/expression-operand.js
@@ -5,6 +5,7 @@ angular.module('ngEquation')
         var operandOptionsApi = {
             class: 'string',
             typeLabel: 'string',
+            editMetadata: 'function',
             getLabel: 'function'
         };
 
@@ -40,6 +41,14 @@ angular.module('ngEquation')
                 ctrl.group.removeOperand(ctrl.options);
             }
         };
+
+        ctrl.editMetadata = function() {
+            ctrl.options.editMetadata();
+        };
+
+        if (ctrl.group) {
+            ctrl.editMetadata();
+        }
     })
     .directive('expressionOperand', function($templateCache) {
         return {

--- a/src/js/expression-operand.js
+++ b/src/js/expression-operand.js
@@ -4,7 +4,8 @@ angular.module('ngEquation')
     .factory('operandOptions', function() {
         var operandOptionsApi = {
             class: 'string',
-            label: 'string'
+            typeLabel: 'string',
+            getLabel: 'function'
         };
 
         function MissingOperandOptionException(property) {

--- a/src/js/expression-operand.js
+++ b/src/js/expression-operand.js
@@ -122,8 +122,7 @@ angular.module('ngEquation')
                                     var newOperandCtrl = angular.element(draggableElement).scope().operand;
 
                                     return dropped &&
-                                        (existingOperandCtrl.options.class !== newOperandCtrl.options.class ||
-                                         existingOperandCtrl.options.label !== newOperandCtrl.options.label);
+                                        (existingOperandCtrl.options.value !== newOperandCtrl.options.value);
                                 }
                             }
                             return false;

--- a/src/js/expression-operand.js
+++ b/src/js/expression-operand.js
@@ -31,7 +31,7 @@ angular.module('ngEquation')
             }
         };
     })
-    .controller('ExpressionOperandCtrl', function(operandOptions) {
+    .controller('ExpressionOperandCtrl', function($q, operandOptions) {
         var ctrl = this;
 
         operandOptions.validate(ctrl.options);
@@ -43,7 +43,10 @@ angular.module('ngEquation')
         };
 
         ctrl.editMetadata = function() {
-            ctrl.options.editMetadata();
+            var editResult = ctrl.options.editMetadata();
+            $q.when(editResult).then(function(result) {
+                ctrl.options.value = result;
+            });
         };
 
         if (ctrl.group) {

--- a/src/templates/expression-group.html
+++ b/src/templates/expression-group.html
@@ -57,7 +57,7 @@
                 ng-class="availableOperand.class"
                 class="eq-operand-menu-item">
                 <a href ng-click="group.addOperand(availableOperand)">
-                    {{availableOperand.label || 'Add Subgroup'}}
+                    {{availableOperand.typeLabel || 'Add Subgroup'}}
                 </a>
             </li>
             <li>

--- a/src/templates/expression-operand.html
+++ b/src/templates/expression-operand.html
@@ -1,7 +1,12 @@
 <span style="display: inline-block">
     <span class="eq-operand" style="display: inline-block"
         ng-class="operand.options.class">
-        {{operand.options.label}}
+        <span ng-if="operand.options.value">
+            {{operand.options.getLabel(operand.options)}}
+        </span>
+        <span ng-if="!operand.options.value">
+            {{operand.options.typeLabel}}
+        </span>
 
         <button class="eq-remove-operand"
             ng-if="operand.group"

--- a/test/expression-operand-spec.js
+++ b/test/expression-operand-spec.js
@@ -14,17 +14,19 @@ describe('expressionOperand directive', function() {
     beforeEach(inject(function($compile, _$exceptionHandler_, $rootScope, $timeout) {
         $exceptionHandler = _$exceptionHandler_;
 
-        instantiate = function(options) {
+        instantiate = function(options, group) {
             var controller;
 
             // use $timeout to allow for exception assertions
             $timeout(function() {
                 $scope = $rootScope.$new();
                 $scope.myOptions = options;
+                $scope.myGroup = group;
 
                 var element = angular.element(
                     '<expression-operand ' +
-                        'operand-options="myOptions">' +
+                        'operand-options="myOptions" ' +
+                        'group="myGroup">' +
                     '</expression-operand>'
                 );
                 $compile(element)($scope);
@@ -42,11 +44,12 @@ describe('expressionOperand directive', function() {
         it('should raise a missing option exception', function() {
             var operandOptions = {
                 class: 'foo',
-                typeLabel: 'Foo'
+                typeLabel: 'Foo',
+                getLabel: jasmine.createSpy('fooOperand.getLabel')
             };
             instantiate(operandOptions);
             expect($exceptionHandler.errors[0].error).toEqual(
-                'Operand options missing required property "getLabel".'
+                'Operand options missing required property "editMetadata".'
             );
         });
     });
@@ -56,26 +59,54 @@ describe('expressionOperand directive', function() {
             var operandOptions = {
                 class: 'foo',
                 typeLabel: 'Foo',
-                getLabel: 'foo?'
+                getLabel: jasmine.createSpy('fooOperand.getLabel'),
+                editMetadata: 'edit?'
             };
             instantiate(operandOptions);
             expect($exceptionHandler.errors[0].error).toEqual(
-                'Operand options property "getLabel" is incorrect type. Expected: "function". Got: "string".'
+                'Operand options property "editMetadata" is incorrect type. Expected: "function". Got: "string".'
             );
         });
     });
 
     describe('with valid options', function() {
+        var controller,
+            operandOptions;
+
+        beforeEach(function() {
+            operandOptions = {
+                class: 'foo',
+                typeLabel: 'Foo',
+                getLabel: jasmine.createSpy('fooOperand.getLabel'),
+                editMetadata: jasmine.createSpy('fooOperand.editMetadata')
+            };
+            controller = instantiate(operandOptions);
+        });
+
         it('should have a "getLabel" method for displaying its value', function() {
+            controller.options.getLabel();
+            expect(operandOptions.getLabel).toHaveBeenCalled();
+        });
+
+        it('should have an "editMetadata" method for setting its value', function() {
+            controller.options.editMetadata();
+            expect(operandOptions.editMetadata).toHaveBeenCalled();
+        });
+    });
+
+    describe('in a group', function() {
+        it('should immediately call editMetadata', function() {
             var operandOptions = {
                 class: 'foo',
                 typeLabel: 'Foo',
-                getLabel: jasmine.createSpy('fooOperand.getLabel')
+                getLabel: function() {
+                    return 'foo';
+                },
+                editMetadata: jasmine.createSpy('fooOperand.editMetadata')
             };
-            var controller = instantiate(operandOptions);
+            instantiate(operandOptions, {message: "I'm a group!"});
 
-            controller.options.getLabel();
-            expect(operandOptions.getLabel).toHaveBeenCalled();
+            expect(operandOptions.editMetadata).toHaveBeenCalled();
         });
     });
 });

--- a/test/expression-operand-spec.js
+++ b/test/expression-operand-spec.js
@@ -39,28 +39,43 @@ describe('expressionOperand directive', function() {
     }));
 
     describe('with required options missing', function() {
-        it('should raise a missing operand exception', function() {
-            instantiate({class: 'foo'});
+        it('should raise a missing option exception', function() {
+            var operandOptions = {
+                class: 'foo',
+                typeLabel: 'Foo'
+            };
+            instantiate(operandOptions);
             expect($exceptionHandler.errors[0].error).toEqual(
-                'Operand options missing required property "label".'
+                'Operand options missing required property "getLabel".'
             );
         });
     });
 
     describe('with required option of incorrect type', function() {
         it('should raise an operand type exception', function() {
-            instantiate({class: 2, label: 'Foo'});
+            var operandOptions = {
+                class: 'foo',
+                typeLabel: 'Foo',
+                getLabel: 'foo?'
+            };
+            instantiate(operandOptions);
             expect($exceptionHandler.errors[0].error).toEqual(
-                'Operand options property "class" is incorrect type. Expected: "string". Got: "number".'
+                'Operand options property "getLabel" is incorrect type. Expected: "function". Got: "string".'
             );
         });
     });
 
     describe('with valid options', function() {
-        it('should have class and label', function() {
-            var controller = instantiate({class: 'foo', label: 'Bar'});
-            expect(controller.options.class).toEqual('foo');
-            expect(controller.options.label).toEqual('Bar');
+        it('should have a "getLabel" method for displaying its value', function() {
+            var operandOptions = {
+                class: 'foo',
+                typeLabel: 'Foo',
+                getLabel: jasmine.createSpy('fooOperand.getLabel')
+            };
+            var controller = instantiate(operandOptions);
+
+            controller.options.getLabel();
+            expect(operandOptions.getLabel).toHaveBeenCalled();
         });
     });
 });

--- a/test/expression-operand-spec.js
+++ b/test/expression-operand-spec.js
@@ -78,7 +78,9 @@ describe('expressionOperand directive', function() {
                 class: 'foo',
                 typeLabel: 'Foo',
                 getLabel: jasmine.createSpy('fooOperand.getLabel'),
-                editMetadata: jasmine.createSpy('fooOperand.editMetadata')
+                editMetadata: jasmine.createSpy('fooOperand.editMetadata').and.callFake(function() {
+                    return 'newValue';
+                })
             };
             controller = instantiate(operandOptions);
         });
@@ -89,8 +91,12 @@ describe('expressionOperand directive', function() {
         });
 
         it('should have an "editMetadata" method for setting its value', function() {
-            controller.options.editMetadata();
+            controller.editMetadata();
             expect(operandOptions.editMetadata).toHaveBeenCalled();
+
+            // trigger `$q.when()` wrapped around result
+            $scope.$apply();
+            expect(controller.options.value).toEqual('newValue');
         });
     });
 


### PR DESCRIPTION
We should reconsider the line in the README:

> Open demo/index.html in browser

I added a `templateUrl` for the fruit operand in the demo, and this will work if you're running a server (e.g. `http-server`) but not when the browser is just loading the demo page from the filesystem.
