### PR TITLE
warn when editMetadata returns a undefined value if a valid value exists

### DIFF
--- a/src/js/expression-operand.js
+++ b/src/js/expression-operand.js
@@ -31,7 +31,7 @@ angular.module('ngEquation')
             }
         };
     })
-    .controller('ExpressionOperandCtrl', function($q, operandOptions) {
+    .controller('ExpressionOperandCtrl', function($q, $log, operandOptions) {
         var ctrl = this;
 
         operandOptions.validate(ctrl.options);
@@ -52,6 +52,8 @@ angular.module('ngEquation')
                     isValueInitialized = true;
                 } else if (!isValueInitialized) {
                     ctrl.removeFromGroup();
+                } else if (angular.isDefined(ctrl.options.value)) {
+                    $log.warn('editMetadata resulted in undefined value, operand will retain previous value of ' + ctrl.options.value);
                 }
             }, function() {
                 if (!isValueInitialized) {

--- a/src/js/expression-operand.js
+++ b/src/js/expression-operand.js
@@ -52,7 +52,7 @@ angular.module('ngEquation')
                     isValueInitialized = true;
                 } else if (!isValueInitialized) {
                     ctrl.removeFromGroup();
-                } else if (angular.isDefined(ctrl.options.value)) {
+                } else {
                     $log.warn('editMetadata resulted in undefined value, operand will retain previous value of ' + ctrl.options.value);
                 }
             }, function() {

--- a/test/expression-operand-spec.js
+++ b/test/expression-operand-spec.js
@@ -2,6 +2,7 @@
 
 describe('expressionOperand directive', function() {
     var $exceptionHandler,
+        $log,
         $scope,
         $q,
         instantiate;
@@ -12,9 +13,10 @@ describe('expressionOperand directive', function() {
         $exceptionHandlerProvider.mode('log');
     }));
 
-    beforeEach(inject(function($compile, _$exceptionHandler_, $rootScope, $timeout, _$q_) {
+    beforeEach(inject(function($compile, _$exceptionHandler_, $rootScope, $timeout, _$q_, _$log_) {
         $exceptionHandler = _$exceptionHandler_;
         $q = _$q_;
+        $log = _$log_;
 
         instantiate = function(options, group) {
             var controller;
@@ -141,6 +143,9 @@ describe('expressionOperand directive', function() {
             controller.editMetadata();
             $scope.$apply();
             expect(controller.removeFromGroup).not.toHaveBeenCalled();
+            expect($log.warn.logs).toEqual([[
+                'editMetadata resulted in undefined value, operand will retain previous value of bar'
+            ]]);
         });
 
         it('should not call "removeFromGroup" when operand\'s "editMetadata" is a rejected promise', function() {


### PR DESCRIPTION
we don't update the value in this case, so a console warning is generated
