### PR TITLE
Add multiple operands at once

### DIFF
--- a/demo/fruit.js
+++ b/demo/fruit.js
@@ -19,7 +19,7 @@ angular.module('exampleApp')
                     $scope.fruit = {};
                     $scope.submit = function() {
                         var value = $scope.fruit.selected && $scope.fruit.selected.value;
-                        $uibModalInstance.close(value);
+                        $uibModalInstance.close({value: value});
                     };
                     $scope.cancel = function() {
                         $uibModalInstance.dismiss();

--- a/demo/fruit.js
+++ b/demo/fruit.js
@@ -16,10 +16,17 @@ angular.module('exampleApp')
                     $scope.fruits = fruits.map(function(fruit) {
                         return {label: capitalize(fruit), value: fruit};
                     });
-                    $scope.fruit = {};
+                    $scope.fruit = {
+                        selected: [{}]
+                    };
+                    $scope.addAnother = function() {
+                        $scope.fruit.selected.push({});
+                    };
                     $scope.submit = function() {
-                        var value = $scope.fruit.selected && $scope.fruit.selected.value;
-                        $uibModalInstance.close({value: value});
+                        var values = $scope.fruit.selected.map(function(fruit) {
+                            return fruit.obj.value;
+                        });
+                        $uibModalInstance.close({value: values, addMultiple: true});
                     };
                     $scope.cancel = function() {
                         $uibModalInstance.dismiss();

--- a/demo/templates/fruit-select-modal.html
+++ b/demo/templates/fruit-select-modal.html
@@ -1,12 +1,19 @@
 <div class="modal-body">
     <div class="form-group">
         <label>Fruit</label>
-        <select
-            class="form-control"
-            ng-options="fruit.label for fruit in fruits track by fruit.value"
-            ng-model="fruit.selected">
-        </select>
+        <div ng-repeat="selection in fruit.selected">
+            <select
+                class="form-control"
+                ng-options="fruit.label for fruit in fruits track by fruit.value"
+                ng-model="selection.obj">
+            </select>
+        </div>
     </div>
+
+    <button class="btn btn-primary"
+        ng-click="addAnother()">
+        Add Another
+    </button>
 </div>
 <div class="modal-footer">
     <button ng-click="submit()">Submit</button>

--- a/src/js/expression-operand.js
+++ b/src/js/expression-operand.js
@@ -44,11 +44,34 @@ angular.module('ngEquation')
             }
         };
 
+        function addAdditionalOperands(values) {
+            if (ctrl.group) {
+                angular.forEach(values, function(value) {
+                    var newOperand = angular.copy(ctrl.options);
+                    newOperand.value = value;
+                    ctrl.group.addOperand(newOperand);
+                });
+            } else {
+                $log.error('unable to add additional operands because there is no group');
+            }
+        }
+
         ctrl.editMetadata = function() {
             var editResult = ctrl.options.editMetadata();
             $q.when(editResult).then(function(result) {
-                if (result && angular.isDefined(result.value)) {
-                    ctrl.options.value = result.value;
+                var value = result && result.value,
+                    addMultiple = result && result.addMultiple;
+
+                if (angular.isDefined(value)) {
+                    if (angular.isArray(value) && addMultiple) {
+                        ctrl.options.value = value[0];
+                        addAdditionalOperands(value.slice(1));
+                    } else if (!angular.isArray(value) && addMultiple) {
+                        $log.error('editMetadata did not return an array but had "addMultiple" turned on');
+                    } else {
+                        ctrl.options.value = value;
+                    }
+
                     isValueInitialized = true;
                 } else if (!isValueInitialized) {
                     ctrl.removeFromGroup();

--- a/src/js/expression-operand.js
+++ b/src/js/expression-operand.js
@@ -67,7 +67,7 @@ angular.module('ngEquation')
                         ctrl.options.value = value[0];
                         addAdditionalOperands(value.slice(1));
                     } else if (!angular.isArray(value) && addMultiple) {
-                        $log.error('editMetadata did not return an array but had "addMultiple" turned on');
+                        $log.error('editMetadata must return an array when using the "addMultiple" option');
                     } else {
                         ctrl.options.value = value;
                     }

--- a/src/js/expression-operand.js
+++ b/src/js/expression-operand.js
@@ -47,8 +47,8 @@ angular.module('ngEquation')
         ctrl.editMetadata = function() {
             var editResult = ctrl.options.editMetadata();
             $q.when(editResult).then(function(result) {
-                if (angular.isDefined(result)) {
-                    ctrl.options.value = result;
+                if (result && angular.isDefined(result.value)) {
+                    ctrl.options.value = result.value;
                     isValueInitialized = true;
                 } else if (!isValueInitialized) {
                     ctrl.removeFromGroup();

--- a/test/expression-operand-spec.js
+++ b/test/expression-operand-spec.js
@@ -83,7 +83,9 @@ describe('expressionOperand directive', function() {
                 typeLabel: 'Foo',
                 getLabel: jasmine.createSpy('fooOperand.getLabel'),
                 editMetadata: jasmine.createSpy('fooOperand.editMetadata').and.callFake(function() {
-                    return 'newValue';
+                    return {
+                        value: 'newValue'
+                    };
                 })
             };
             controller = instantiate(operandOptions);

--- a/test/expression-operand-spec.js
+++ b/test/expression-operand-spec.js
@@ -191,4 +191,55 @@ describe('expressionOperand directive', function() {
             expect(operandOptions.editMetadata).not.toHaveBeenCalled();
         });
     });
+
+    describe('configured to add multiple operands at once', function() {
+        var group,
+            operandOptions = {
+                class: 'foos',
+                typeLabel: 'Foos',
+                getLabel: function() {
+                    return 'foos';
+                }
+            };
+
+        beforeEach(function() {
+            group = {
+                addOperand: jasmine.createSpy('group.addOperand')
+            };
+            operandOptions.editMetadata = function() {
+                return {
+                    value: ['a', 'b', 'c'],
+                    addMultiple: true
+                };
+            };
+
+            instantiate(operandOptions, group);
+        });
+
+        it('should call addOperand for the additional values returned from editMetadata', function() {
+            var allAddOperandCallArgs = group.addOperand.calls.all().map(function(call) {
+                return call.args;
+            });
+            expect(allAddOperandCallArgs).toEqual([
+                [
+                    {
+                        class: 'foos',
+                        typeLabel: 'Foos',
+                        getLabel: jasmine.any(Function),
+                        editMetadata: jasmine.any(Function),
+                        value: 'b'
+                    }
+                ],
+                [
+                    {
+                        class: 'foos',
+                        typeLabel: 'Foos',
+                        getLabel: jasmine.any(Function),
+                        editMetadata: jasmine.any(Function),
+                        value: 'c'
+                    }
+                ]
+            ]);
+        });
+    });
 });


### PR DESCRIPTION
From demo page:

``` javascript
$uibModalInstance.close({value: values, addMultiple: true});
```

This is what an `editMetadata` return value should look like, to enable adding multiple operands at once. The `result.value` must be an array (_when passing `addMultiple: true`_) or an error is logged.

``` javascript
$uibModalInstance.close({value: value});
```

This would be a standard single-value response for `editMetadata`. These responses must all be wrapped in objects now.
