### PR TITLE
Confirm before removal of operand/subgroup

### DIFF
--- a/src/js/expression-group.js
+++ b/src/js/expression-group.js
@@ -4,6 +4,8 @@ angular.module('ngEquation')
     .controller('ExpressionGroupCtrl', function() {
         var ctrl = this;
 
+        ctrl.confirmTemplate = 'confirm-popover.html';
+
         ctrl.addOperand = function(operand) {
             ctrl.operands.push(angular.copy(operand));
         };

--- a/src/js/expression-operand.js
+++ b/src/js/expression-operand.js
@@ -34,6 +34,8 @@ angular.module('ngEquation')
     .controller('ExpressionOperandCtrl', function($q, $log, operandOptions) {
         var ctrl = this;
 
+        ctrl.confirmTemplate = 'confirm-popover.html';
+
         operandOptions.validate(ctrl.options);
 
         var isValueInitialized = angular.isDefined(ctrl.options.value);

--- a/src/less/ng-equation-basic.less
+++ b/src/less/ng-equation-basic.less
@@ -37,6 +37,11 @@
     }
 
     .eq-group {
+        .popover-content .btn-xs {
+            background-color: red;
+            color: white;
+        }
+
         .eq-new-operand {
             &.drop-target {
                 background-color: @lime-green;

--- a/src/less/ng-equation-basic.less
+++ b/src/less/ng-equation-basic.less
@@ -30,6 +30,10 @@
                 display: block;
             }
         }
+
+        .popover-content .btn-xs {
+            background-color: @light-red;
+        }
     }
 
     .eq-group {

--- a/src/less/ng-equation.less
+++ b/src/less/ng-equation.less
@@ -17,6 +17,10 @@
         -ms-transform: translate(0, 0);
         -o-transform: translate(0, 0);
         transform: translate(0, 0);
+
+        .popover-content {
+            padding: 3px;
+        }
     }
 
     .eq-edit-operand, .eq-remove-operand {

--- a/src/less/ng-equation.less
+++ b/src/less/ng-equation.less
@@ -55,6 +55,10 @@
         border-radius: 5px;
         padding: 15px;
 
+        .popover-content {
+            padding: 3px;
+        }
+
         .eq-new-operand {
             border: 1px solid transparent;
             border-radius: 5px;

--- a/src/templates/confirm-popover.html
+++ b/src/templates/confirm-popover.html
@@ -1,0 +1,7 @@
+<div class="eq-confirm-popup">
+    <button class="btn btn-xs"
+        ng-click="operand.removeFromGroup()">
+        Confirm
+        <i class="glyphicon glyphicon-ok-sign"></i>
+    </button>
+</div>

--- a/src/templates/confirm-popover.html
+++ b/src/templates/confirm-popover.html
@@ -1,6 +1,6 @@
 <div class="eq-confirm-popup">
     <button class="btn btn-xs"
-        ng-click="operand.removeFromGroup()">
+        ng-click="operand ? operand.removeFromGroup() : group.parent.removeSubgroup(group.subgroupId)">
         Confirm
         <i class="glyphicon glyphicon-ok-sign"></i>
     </button>

--- a/src/templates/expression-group.html
+++ b/src/templates/expression-group.html
@@ -72,7 +72,8 @@
 
     <button class="eq-remove-group"
         ng-if="group.parent"
-        ng-click="group.parent.removeSubgroup(group.subgroupId)">
+        uib-popover-template="group.confirmTemplate"
+        popover-trigger="outsideClick">
         Remove Group
     </button>
 </span>

--- a/src/templates/expression-operand.html
+++ b/src/templates/expression-operand.html
@@ -16,7 +16,8 @@
 
         <button class="eq-remove-operand"
             ng-if="operand.group"
-            ng-click="operand.removeFromGroup()">
+            uib-popover-template="operand.confirmTemplate"
+            popover-trigger="outsideClick">
             &times;
         </button>
     </span>


### PR DESCRIPTION
Tiny popover appears, to request confirmation before proceeding with deletion of operand/subgroup.
