### PR TITLE
add optional tooltips for operands

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/src/js/exceptions/missing-operand-option-exception.js
+++ b/src/js/exceptions/missing-operand-option-exception.js
@@ -1,0 +1,13 @@
+'use strict';
+
+angular.module('ngEquation')
+    .factory('MissingOperandOptionException', function() {
+        function MissingOperandOptionException(property) {
+            this.message = 'Operand options missing required property "' + property + '".';
+            this.stack = (new Error()).stack;
+        }
+        MissingOperandOptionException.prototype = Object.create(Error.prototype);
+        MissingOperandOptionException.prototype.constructor = MissingOperandOptionException;
+        MissingOperandOptionException.prototype.name = 'MissingOperandOptionException';
+        return MissingOperandOptionException;
+    });

--- a/src/js/exceptions/operand-option-type-exception.js
+++ b/src/js/exceptions/operand-option-type-exception.js
@@ -1,0 +1,15 @@
+'use strict';
+
+angular.module('ngEquation')
+    .factory('OperandOptionTypeException', function() {
+        function OperandOptionTypeException(property, expectedType, propertyType) {
+            this.message = 'Operand options property "' + property + '" is incorrect type. ' +
+                'Expected: "' + expectedType + '". ' +
+                'Got: "' + propertyType + '".';
+            this.stack = (new Error()).stack;
+        }
+        OperandOptionTypeException.prototype = Object.create(Error.prototype);
+        OperandOptionTypeException.prototype.constructor = OperandOptionTypeException;
+        OperandOptionTypeException.prototype.name = 'OperandOptionTypeException';
+        return OperandOptionTypeException;
+    });

--- a/src/js/expression-operand.js
+++ b/src/js/expression-operand.js
@@ -18,6 +18,10 @@ angular.module('ngEquation')
             getLabel: {
                 type: 'function',
                 required: true
+            },
+            getTooltipText: {
+                type: 'function',
+                required: false
             }
         };
 

--- a/src/js/expression-operand.js
+++ b/src/js/expression-operand.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('ngEquation')
-    .factory('operandOptions', function() {
+    .factory('operandOptions', function(MissingOperandOptionException, OperandOptionTypeException) {
         var operandOptionsApi = {
             class: {
                 type: 'string',
@@ -20,16 +20,6 @@ angular.module('ngEquation')
                 required: true
             }
         };
-
-        function MissingOperandOptionException(property) {
-            this.error = 'Operand options missing required property "' + property + '".';
-        }
-
-        function OperandOptionTypeException(property, expectedType, propertyType) {
-            this.error = 'Operand options property "' + property + '" is incorrect type. ' +
-                'Expected: "' + expectedType + '". ' +
-                'Got: "' + propertyType + '".';
-        }
 
         return {
             validate: function(obj) {

--- a/src/js/expression-operand.js
+++ b/src/js/expression-operand.js
@@ -3,10 +3,22 @@
 angular.module('ngEquation')
     .factory('operandOptions', function() {
         var operandOptionsApi = {
-            class: 'string',
-            typeLabel: 'string',
-            editMetadata: 'function',
-            getLabel: 'function'
+            class: {
+                type: 'string',
+                required: true
+            },
+            typeLabel: {
+                type: 'string',
+                required: true
+            },
+            editMetadata: {
+                type: 'function',
+                required: true
+            },
+            getLabel: {
+                type: 'function',
+                required: true
+            }
         };
 
         function MissingOperandOptionException(property) {
@@ -21,11 +33,11 @@ angular.module('ngEquation')
 
         return {
             validate: function(obj) {
-                angular.forEach(operandOptionsApi, function(propertyType, apiProperty) {
-                    if (!obj[apiProperty]) {
-                        throw new MissingOperandOptionException(apiProperty);
-                    } else if (typeof(obj[apiProperty]) !== propertyType) {
-                        throw new OperandOptionTypeException(apiProperty, propertyType, typeof(obj[apiProperty]));
+                angular.forEach(operandOptionsApi, function(propertyOptions, propertyName) {
+                    if (propertyOptions.required && !(propertyName in obj)) {
+                        throw new MissingOperandOptionException(propertyName);
+                    } else if (propertyName in obj && typeof(obj[propertyName]) !== propertyOptions.type) {
+                        throw new OperandOptionTypeException(propertyName, propertyOptions.type, typeof(obj[propertyName]));
                     }
                 });
             }

--- a/src/templates/expression-operand.html
+++ b/src/templates/expression-operand.html
@@ -1,6 +1,8 @@
 <span style="display: inline-block">
-    <span class="eq-operand" style="display: inline-block"
-        ng-class="operand.options.class">
+    <span class="eq-operand"
+          style="display: inline-block"
+          ng-class="operand.options.class"
+          uib-tooltip="{{ operand.options.getTooltipText(operand.options) }}">
         <span ng-if="operand.options.value">
             {{operand.options.getLabel(operand.options)}}
         </span>

--- a/test/expression-operand-spec.js
+++ b/test/expression-operand-spec.js
@@ -79,6 +79,24 @@ describe('expressionOperand directive', function() {
         });
     });
 
+    describe('with optional option of incorrect type', function() {
+        it('should raise an operand type exception', function() {
+            var operandOptions = {
+                class: 'foo',
+                typeLabel: 'Foo',
+                getLabel: jasmine.createSpy('fooOperand.getLabel'),
+                editMetadata: jasmine.createSpy('fooOperand.editMetadata'),
+                getTooltipText: 'foo tooltip text'
+            };
+            expect(function() {
+                instantiate(operandOptions);
+            }).toThrowError(
+                OperandOptionTypeException,
+                'Operand options property "getTooltipText" is incorrect type. Expected: "function". Got: "string".'
+            );
+        });
+    });
+
     describe('with valid options', function() {
         var controller,
             operandOptions;
@@ -92,6 +110,9 @@ describe('expressionOperand directive', function() {
                     return {
                         value: 'newValue'
                     };
+                }),
+                getTooltipText: jasmine.createSpy('fooOperand.getTooltipText').and.callFake(function() {
+                    return 'this is a foo operand';
                 })
             };
             controller = instantiate(operandOptions);


### PR DESCRIPTION
- add an optional `getTooltipText` parameter to the `operandOptionsApi`
- make `MissingOperandOptionException` and `OperandOptionTypeException` both extend `Error` and define them in their own functions
- add .editorconfig file
