### PR TITLE
append operand tooltip to body

### DIFF
--- a/dist/ng-equation-templates.js
+++ b/dist/ng-equation-templates.js
@@ -135,7 +135,8 @@ angular.module("expression-operand.html", []).run(["$templateCache", function($t
     "    <span class=\"eq-operand\"\n" +
     "          style=\"display: inline-block\"\n" +
     "          ng-class=\"operand.options.class\"\n" +
-    "          uib-tooltip=\"{{ operand.options.getTooltipText(operand.options) }}\">\n" +
+    "          uib-tooltip=\"{{ operand.options.getTooltipText(operand.options) }}\"\n" +
+    "          tooltip-append-to-body=\"true\">\n" +
     "        <span ng-if=\"operand.options.value\">\n" +
     "            {{operand.options.getLabel(operand.options)}}\n" +
     "        </span>\n" +

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-equation",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Boolean Equation Builder for complex data",
   "dependencies": {},
   "devDependencies": {

--- a/src/templates/expression-operand.html
+++ b/src/templates/expression-operand.html
@@ -2,7 +2,8 @@
     <span class="eq-operand"
           style="display: inline-block"
           ng-class="operand.options.class"
-          uib-tooltip="{{ operand.options.getTooltipText(operand.options) }}">
+          uib-tooltip="{{ operand.options.getTooltipText(operand.options) }}"
+          tooltip-append-to-body="true">
         <span ng-if="operand.options.value">
             {{operand.options.getLabel(operand.options)}}
         </span>


### PR DESCRIPTION
this fixes z-index issues where the only part of the tooltip that is visible is
the part within the operand's group's bounding rectangle
