### PR TITLE
Popover placement

### DIFF
--- a/dist/ng-equation-templates.js
+++ b/dist/ng-equation-templates.js
@@ -150,6 +150,7 @@ angular.module("expression-operand.html", []).run(["$templateCache", function($t
     "          style=\"display: inline-block\"\n" +
     "          ng-class=\"operand.options.class\"\n" +
     "          uib-tooltip=\"{{ operand.options.getTooltipText(operand.options) }}\"\n" +
+    "          tooltip-placement=\"{{operand.options.tooltipPlacement || 'bottom'}}\"\n" +
     "          tooltip-append-to-body=\"true\">\n" +
     "\n" +
     "        <span class=\"btn eq-operand-drag-btn\">\n" +

--- a/dist/ng-equation.js
+++ b/dist/ng-equation.js
@@ -427,7 +427,7 @@ angular.module("ngEquation", [ "ui.bootstrap", "ngEquation.templates" ]), angula
                 ondropdeactivate: function(event) {
                     event.target.classList.remove("drop-active"), event.target.classList.remove("drop-target");
                 }
-            }).allowFrom(".eq-operand-drag-btn").actionChecker(function(pointer, event, action) {
+            }).allowFrom(".eq-operand-drag-btn").actionChecker(function(_pointer, event, action) {
                 return 0 !== event.button ? null : action;
             });
         }

--- a/src/js/util/expression-operand-drag-n-drop.js
+++ b/src/js/util/expression-operand-drag-n-drop.js
@@ -171,7 +171,7 @@ angular.module('ngEquation')
                         }
                     })
                     .allowFrom('.eq-operand-drag-btn')
-                    .actionChecker(function(pointer, event, action) {
+                    .actionChecker(function(_pointer, event, action) {
                         if (event.button !== 0) {
                             return null;
                         }

--- a/src/templates/expression-operand.html
+++ b/src/templates/expression-operand.html
@@ -3,6 +3,7 @@
           style="display: inline-block"
           ng-class="operand.options.class"
           uib-tooltip="{{ operand.options.getTooltipText(operand.options) }}"
+          tooltip-placement="{{operand.options.tooltipPlacement || 'bottom'}}"
           tooltip-append-to-body="true">
 
         <span class="btn eq-operand-drag-btn">


### PR DESCRIPTION
Default the popover placement to be under the operand because it could overlap with the edit/delete buttons.  Allow the placement to be configured from the operand options.